### PR TITLE
Add configurable boss settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Spawn an overpowered zombie boss in PocketMine-MP. Use `/spawnboss` in-game to s
 
 The boss has high health and custom battle AI with combo moves, including leaping attacks,
 summoning minions, and temporary strength boosts. Challenge your players with a tough fight!
+
+## Configuration
+
+ZombieBoss reads `config.yml` for all of its stats. After first start a default configuration
+is generated in the plugin data folder:
+
+```yaml
+health: 1000
+movement-speed: 0.4
+attack-damage: 20.0
+combo-cooldown: 200
+minion-count: 3
+```
+
+Edit these values to tune the boss difficulty. Run `/zbreload` to reload the configuration
+without restarting your server.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,13 +1,20 @@
 name: ZombieBoss
 main: ZombieBoss\\Main
-version: 1.0.0
+version: 1.1.0
 api: 5.0.0
 author: ChatGPT
+description: Summon a challenging and fully configurable zombie boss
 commands:
   spawnboss:
     description: Spawn the zombie boss
     usage: /spawnboss
     permission: zombieboss.command.spawnboss
+  zbreload:
+    description: Reload ZombieBoss configuration
+    usage: /zbreload
+    permission: zombieboss.command.reload
 permissions:
   zombieboss.command.spawnboss:
+    default: op
+  zombieboss.command.reload:
     default: op

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,0 +1,5 @@
+health: 1000
+movement-speed: 0.4
+attack-damage: 20.0
+combo-cooldown: 200
+minion-count: 3

--- a/src/ZombieBoss/Main.php
+++ b/src/ZombieBoss/Main.php
@@ -17,19 +17,27 @@ use ZombieBoss\entity\ZombieBoss as BossEntity;
 class Main extends PluginBase{
 
     protected function onEnable(): void{
+        $this->saveDefaultConfig();
+        BossEntity::loadConfig($this->getConfig());
         EntityFactory::getInstance()->register(BossEntity::class, function(World $world, CompoundTag $nbt): BossEntity{ return new BossEntity(EntityDataHelper::parseLocation($nbt, $world), $nbt); }, ["ZombieBoss"]);
     }
 
     public function onCommand(CommandSender $sender, Command $command, string $label, array $args): bool{
-        if($command->getName() === 'spawnboss'){
-            if(!$sender instanceof Player){
-                $sender->sendMessage('Run this command in-game.');
+        switch($command->getName()){
+            case 'spawnboss':
+                if(!$sender instanceof Player){
+                    $sender->sendMessage('Run this command in-game.');
+                    return true;
+                }
+                $boss = new BossEntity($sender->getLocation());
+                $boss->spawnToAll();
+                $sender->sendMessage('The Zombie Boss has been summoned!');
                 return true;
-            }
-            $boss = new BossEntity($sender->getLocation());
-            $boss->spawnToAll();
-            $sender->sendMessage('The Zombie Boss has been summoned!');
-            return true;
+            case 'zbreload':
+                $this->reloadConfig();
+                BossEntity::loadConfig($this->getConfig());
+                $sender->sendMessage('ZombieBoss configuration reloaded.');
+                return true;
         }
         return false;
     }

--- a/src/ZombieBoss/entity/ZombieBoss.php
+++ b/src/ZombieBoss/entity/ZombieBoss.php
@@ -12,13 +12,33 @@ use pocketmine\entity\effect\{EffectInstance, VanillaEffects};
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\EntitySizeInfo;
+use pocketmine\utils\Config;
 
 class ZombieBoss extends Zombie{
+
+    /** @var float */
+    protected static float $cfgHealth = 1000.0;
+    /** @var float */
+    protected static float $cfgMovementSpeed = 0.4;
+    /** @var float */
+    protected static float $cfgAttackDamage = 20.0;
+    /** @var int ticks */
+    protected static int $cfgComboCooldown = 200;
+    /** @var int */
+    protected static int $cfgMinionCount = 3;
 
     /** @var int ticks */
     protected int $comboCooldown = 0;
 
     protected ?Player $target = null;
+
+    public static function loadConfig(Config $config) : void{
+        self::$cfgHealth = (float) $config->get('health', self::$cfgHealth);
+        self::$cfgMovementSpeed = (float) $config->get('movement-speed', self::$cfgMovementSpeed);
+        self::$cfgAttackDamage = (float) $config->get('attack-damage', self::$cfgAttackDamage);
+        self::$cfgComboCooldown = (int) $config->get('combo-cooldown', self::$cfgComboCooldown);
+        self::$cfgMinionCount = (int) $config->get('minion-count', self::$cfgMinionCount);
+    }
 
     public static function getNetworkTypeId() : string{
         return 'zombieboss:zombie_boss';
@@ -30,11 +50,11 @@ class ZombieBoss extends Zombie{
 
     public function initEntity(CompoundTag $nbt) : void{
         parent::initEntity($nbt);
-        $this->setMaxHealth(1000);
-        $this->setHealth(1000);
+        $this->setMaxHealth(self::$cfgHealth);
+        $this->setHealth(self::$cfgHealth);
         $this->setScale(2.0);
-        $this->getAttributeMap()->get(Attribute::MOVEMENT_SPEED)->setValue(0.4);
-        $this->getAttributeMap()->get(Attribute::ATTACK_DAMAGE)->setValue(20.0);
+        $this->getAttributeMap()->get(Attribute::MOVEMENT_SPEED)->setValue(self::$cfgMovementSpeed);
+        $this->getAttributeMap()->get(Attribute::ATTACK_DAMAGE)->setValue(self::$cfgAttackDamage);
     }
 
     protected function findTarget() : ?Player{
@@ -71,7 +91,7 @@ class ZombieBoss extends Zombie{
 
     protected function summonMinions() : void{
         $world = $this->getWorld();
-        for($i = 0; $i < 3; $i++){
+        for($i = 0; $i < self::$cfgMinionCount; $i++){
             $loc = $this->getLocation()->add(mt_rand(-3, 3), 0, mt_rand(-3, 3));
             $z = new VanillaZombie(Location::fromObject($loc, $world, $this->yaw, 0));
             $z->spawnToAll();
@@ -96,7 +116,7 @@ class ZombieBoss extends Zombie{
 
         if($this->comboCooldown <= 0 && $this->target !== null){
             $this->performCombo();
-            $this->comboCooldown = 200; // 10 seconds
+            $this->comboCooldown = self::$cfgComboCooldown;
         }
 
         return $changed;


### PR DESCRIPTION
## Summary
- add default `config.yml`
- update `README` with configuration instructions
- load config in plugin on enable
- add `/zbreload` command to reload config on the fly
- use configuration values in `ZombieBoss` entity
- bump version to 1.1.0 and document new command in `plugin.yml`

## Testing
- `php -l src/ZombieBoss/Main.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed68e92f48323a25c4829958c2813